### PR TITLE
Fixing CLI not outputting HTML / JSON files as incorrect variable was…

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -113,7 +113,7 @@ const { error, printTestResults, printSupportedPresets, printListSchemas } = req
     .then(async (res) => {
       await printTestResults(res, { showInfo })
       if (testOutput)
-        fs.writeFileSync(testOutput, JSON.stringify(err.res, null, 2))
+        fs.writeFileSync(testOutput, JSON.stringify(res, null, 2))
       return process.exit()
     })
     .catch(async (err) => {


### PR DESCRIPTION
# Summary

Fix for CLI not outputting HTML / JSON files

# Detail

The CLI allows HTML and JSON files to be created using -o [filename] or --output [filename]. This feature was not working and returned "Unable to fetch content from [URL]" error. This was due to err.res being passed to the file writer instead of res (err.res should be used in the catch statement).

